### PR TITLE
Tech 3626 check restricted files

### DIFF
--- a/.github/workflows/check-restricted-files.yml
+++ b/.github/workflows/check-restricted-files.yml
@@ -1,0 +1,50 @@
+name: Check Restricted Files
+
+on:
+  pull_request:
+    paths:
+      - '**/*'
+
+jobs:
+  check_restricted_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Fetch all branches
+        run: git fetch --all
+
+      - name: List all changed files
+        id: changed-files
+        run: |
+          git diff --name-only origin/main > changed_files.txt  || echo "No differences found."
+          cat changed_files.txt
+
+      - name: Check for unauthorized file changes
+        run: |
+          ALLOWED_FILES=(
+            "sync-fork.yml"
+            "check-restricted-files.yml"
+          )
+
+          unauthorized_files=""
+
+          # Loop through each changed file
+          while IFS= read -r file; do
+            # Extract the file name from the path
+            filename=$(basename "$file")
+
+            # Check if the filename is in the allowed files list
+            if ! printf "%s\n" "${ALLOWED_FILES[@]}" | grep -qx "$filename"; then
+              unauthorized_files+="$file"$'\n'
+            fi
+          done < changed_files.txt
+
+          if [[ -n "$unauthorized_files" ]]; then
+            echo "Unauthorized file changes detected:"
+            echo "$unauthorized_files"
+            exit 1
+          else
+            echo "All changed files are authorized."
+          fi

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,89 @@
+name: Sync fork with upstream
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch/es to sync'
+        required: true
+        type: choice
+        options:
+          - 'all'
+          - 'deployments/makerdao'
+          - 'deployments/staging/makerdao'
+  schedule:
+    - cron: '*/30 * * * *'
+
+env:
+  UPSTREAM_REPO: 'powerhouse-inc/connect'
+
+jobs:
+  sync_fork:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout everything
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT }}
+
+      - name: Configure git
+        id: configure_git
+        run: |
+          git config user.email "${{ secrets.SYNC_FORK_USER_EMAIL }}"
+          git config user.name "${{ vars.SYNC_FORK_USER_NAME }}"
+
+      - name: Add upstream
+        id: add_upstream
+        run: |
+          git remote add upstream https://github.com/${{ env.UPSTREAM_REPO }}.git
+
+      - name: Sync fork
+        id: sync
+        shell: bash
+        env:
+          BRANCHES: ${{ ( github.event_name == 'schedule' || github.event.inputs.branch == 'all' ) && 'deployments/makerdao deployments/staging/makerdao' || github.event.inputs.branch }}
+        run: |
+          for BRANCH in $BRANCHES; do
+            git checkout $BRANCH
+            git fetch upstream $BRANCH
+            git checkout upstream/$BRANCH
+            UPSTREAM_SHA_SHORT=$(git rev-parse --short HEAD)
+            git checkout $BRANCH
+            # Check if the latest commit from the upstream is already in the forked repo
+            if [ -z "$(git log | grep $UPSTREAM_SHA_SHORT)" ]; then
+              git merge upstream/$BRANCH --no-edit
+              git push origin $BRANCH
+              echo "Branch $BRANCH synced"
+            else
+              echo "Branch $BRANCH is already up to date"
+            fi
+            echo "Done with $BRANCH"
+          done
+
+      - name: Send an alert to PagerDuty
+        id: alert
+        if: failure()
+        run: |
+          echo "Sending an alert to PagerDuty..."
+          curl -X POST https://events.pagerduty.com/v2/enqueue \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "routing_key": "${{ secrets.SYNC_FORK_PD_ROUTING_KEY }}",
+              "event_action": "trigger",
+              "payload": {
+                "summary": "Sync fork failed for ${{ github.repository }}",
+                "timestamp": "'$(date -u +"%Y-%m-%dT%H:%M:%S")'",
+                "source": "GitHub Actions",
+                "component": "Endgame",
+                "severity": "error",
+                "custom_details": {
+                  "repository": "${{ github.repository }}",
+                  "workflow": "${{ github.workflow }}",
+                  "link": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                }
+              }
+            }'


### PR DESCRIPTION
Added a github workflow to check if any restricted files have been changed, that may cause merge conflicts.
The list of files that are allowed to be changed, for this repo, is defined in the workflow itself.

The job runs when a PR is created. If change to any restricted files is detected, than the job with show as failed, on the PR Dashboard. Github send an email to the creator of the PR, stating that the job has failed.